### PR TITLE
Add Pinia plugin for user store persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "apexcharts": "^5.3.6",
         "cloudinary": "^2.8.0",
         "pinia": "^3.0.3",
+        "pinia-plugin-persistedstate": "^4.7.1",
         "tailwindcss": "^4.1.17",
         "vue": "^3.5.22",
         "vue-router": "^4.6.3",
@@ -3358,6 +3359,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5240,6 +5247,31 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-4.7.1.tgz",
+      "integrity": "sha512-WHOqh2esDlR3eAaknPbqXrkkj0D24h8shrDPqysgCFR6ghqP/fpFfJmMPJp0gETHsvrh9YNNg6dQfo2OEtDnIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": ">=3.0.0",
+        "@pinia/nuxt": ">=0.10.0",
+        "pinia": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        },
+        "@pinia/nuxt": {
+          "optional": true
+        },
+        "pinia": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apexcharts": "^5.3.6",
     "cloudinary": "^2.8.0",
     "pinia": "^3.0.3",
+    "pinia-plugin-persistedstate": "^4.7.1",
     "tailwindcss": "^4.1.17",
     "vue": "^3.5.22",
     "vue-router": "^4.6.3",

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,16 @@
 import './assets/main.css'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
 import App from './App.vue'
 import router from './router'
 
 const app = createApp(App)
+const pinia = createPinia();
+pinia.use(piniaPluginPersistedstate)
 
-app.use(createPinia())
+app.use(pinia)
 app.use(router)
 
 app.mount('#app')

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -26,6 +26,10 @@ export const useUserStore = defineStore('userStore', {
     // Household challenges (set by admin)
     householdChallenges: [],
   }),
+  persist: {
+    storage: localStorage,
+    pick: ['currentUser','currentProfile']
+  },
 
   getters: {
     // Check if user is logged in (email/password authenticated)


### PR DESCRIPTION
Integrate `pinia-plugin-persistedstate` to enable persistence for the user store, ensuring that user data remains available across sessions. This change enhances the user experience by retaining user state in local storage.